### PR TITLE
fix: Rename tasks to taskIds in mock_lessons

### DIFF
--- a/mock_lessons.json
+++ b/mock_lessons.json
@@ -44,7 +44,7 @@
                 ]
             }
         ],
-        "tasks": [
+        "taskIds": [
             "task2",
             "task1"
         ]
@@ -94,7 +94,7 @@
                 ]
             }
         ],
-        "tasks": [
+        "taskIds": [
             "task8",
             "task9"
         ]
@@ -144,7 +144,7 @@
                 ]
             }
         ],
-        "tasks": [
+        "taskIds": [
             "task5",
             "task10"
         ]
@@ -194,7 +194,7 @@
                 ]
             }
         ],
-        "tasks": [
+        "taskIds": [
             "task4",
             "task6"
         ]
@@ -203,7 +203,7 @@
         "id": "lesson5",
         "title": {
             "de": "Lektion ohne Aufgaben",
-            "en": "Lesson Without Tasks"
+            "en": "Lesson Without TaskIds"
         },
         "pages": [
             {
@@ -244,7 +244,7 @@
                 ]
             }
         ],
-        "tasks": []
+        "taskIds": []
     },
     {
         "id": "lesson6",
@@ -253,7 +253,7 @@
             "en": "Lesson Without Pages"
         },
         "pages": [],
-        "tasks": [
+        "taskIds": [
             "task2",
             "task1"
         ]
@@ -265,6 +265,6 @@
             "en": "Empty Lesson"
         },
         "pages": [],
-        "tasks": []
+        "taskIds": []
     }
 ]


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

This PR renames `tasks` to `taskIds` to use the expected key.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
