### PR TITLE
refactor: Rename page to view to unify naming

### DIFF
--- a/lib/features/lessons/lessons_route.dart
+++ b/lib/features/lessons/lessons_route.dart
@@ -4,7 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:lessons_tasks_assignment/features/lesson/lesson_route.dart';
 import 'package:lessons_tasks_assignment/features/lessons/cubit/lessons_cubit.dart';
-import 'package:lessons_tasks_assignment/features/lessons/view/lessons_page.dart';
+import 'package:lessons_tasks_assignment/features/lessons/view/lessons_view.dart';
 import 'package:lessons_tasks_assignment/repositories/lessons/interceptors/json_interceptor.dart';
 import 'package:lessons_tasks_assignment/repositories/lessons/lessons_repository.dart';
 import 'package:lessons_tasks_assignment/repositories/lessons/rest_client.dart';
@@ -30,7 +30,7 @@ class LessonsRoute extends GoRouteData {
     );
     return BlocProvider(
       create: (context) => LessonsCubit(lessonsRepository)..fetchLessons(),
-      child: const LessonsPage(),
+      child: const LessonsView(),
     );
   }
 }

--- a/lib/features/lessons/view/lessons_view.dart
+++ b/lib/features/lessons/view/lessons_view.dart
@@ -7,14 +7,14 @@ import 'package:lessons_tasks_assignment/features/lessons/cubit/lessons_state.da
 import 'package:lessons_tasks_assignment/features/lessons/lessons_route.dart';
 import 'package:lessons_tasks_assignment/l10n/l10n.dart';
 
-class LessonsPage extends StatelessWidget {
-  const LessonsPage({super.key});
+class LessonsView extends StatelessWidget {
+  const LessonsView({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(context.l10n.lessonsPageTitle),
+        title: Text(context.l10n.lessonsViewTitle),
       ),
       body: BlocBuilder<LessonsCubit, LessonsState>(
         builder: (context, state) {

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1,35 +1,35 @@
 {
     "@@locale": "de",
-    "lessonsPageTitle": "Lektionen",
-    "@lessonsPageTitle": {
-        "description": "Title of the lessons page"
+    "lessonsViewTitle": "Lektionen",
+    "@lessonsViewTitle": {
+        "description": "Titel der Lektionen-Seite"
     },
     "lessonsPages": "{count, plural, =0{keine Seiten} =1{eine Seite} other{{count} Seiten}}",
     "@lessonsPages": {
-        "description": "Number of pages in a lesson",
+        "description": "Anzahl der Seiten einer Lektion",
         "placeholders": {
             "count": {
                 "type": "int",
-                "description": "Number of pages"
+                "description": "Anzahl der Seiten"
             }
         }
     },
     "lessonsTasks": "{count, plural, =0{keine Aufgaben} =1{eine Aufgabe} other{{count} Aufgaben}}",
     "@lessonsTasks": {
-        "description": "Number of tasks in a lesson",
+        "description": "Anzahl der Aufgaben einer Lektion",
         "placeholders": {
             "count": {
                 "type": "int",
-                "description": "Number of tasks"
+                "description": "Anzahl der Aufgaben"
             }
         }
     },
     "lessonsTryAgain": "Nochmal versuchen",
     "@lessonsTryAgain": {
-        "description": "Text of the button to try again"
+        "description": "Text des Buttons zum erneuten Versuchen"
     },
     "lessonsEmpty": "Keine Lektionen gefunden",
     "@lessonsEmpty": {
-        "description": "Text shown when there are no lessons"
+          "description": "Text, der angezeigt wird, wenn keine Lektionen gefunden werden"
     }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1,8 +1,8 @@
 {
     "@@locale": "en",
-    "lessonsPageTitle": "Lessons",
-    "@lessonsPageTitle": {
-        "description": "Title of the lessons page"
+    "lessonsViewTitle": "Lessons",
+    "@lessonsViewTitle": {
+        "description": "Title of the lessons view"
     },
     "lessonsPages": "{count, plural, =0{no pages} =1{one page} other{{count} pages}}",
     "@lessonsPages": {

--- a/test/features/lessons/view/lessons_view_test.dart
+++ b/test/features/lessons/view/lessons_view_test.dart
@@ -8,7 +8,7 @@ import 'package:lessons_tasks_assignment/domain/page.dart' as page;
 import 'package:lessons_tasks_assignment/domain/task.dart';
 import 'package:lessons_tasks_assignment/features/lessons/cubit/lessons_cubit.dart';
 import 'package:lessons_tasks_assignment/features/lessons/cubit/lessons_state.dart';
-import 'package:lessons_tasks_assignment/features/lessons/view/lessons_page.dart';
+import 'package:lessons_tasks_assignment/features/lessons/view/lessons_view.dart';
 import 'package:lessons_tasks_assignment/l10n/l10n.dart';
 import 'package:mockito/mockito.dart';
 
@@ -28,17 +28,17 @@ void main() {
     return tester.pumpApp(
       widget: BlocProvider<LessonsCubit>.value(
         value: cubit,
-        child: const LessonsPage(),
+        child: const LessonsView(),
       ),
     );
   }
 
-  group('LessonsPage', () {
+  group('LessonsView', () {
     testWidgets('has correct title', (WidgetTester tester) async {
       when(cubit.state).thenReturn(const LessonsState.initial());
       await pumpTestWidget(tester);
-      final BuildContext context = tester.element(find.byType(LessonsPage));
-      expect(find.text(context.l10n.lessonsPageTitle), findsOneWidget);
+      final BuildContext context = tester.element(find.byType(LessonsView));
+      expect(find.text(context.l10n.lessonsViewTitle), findsOneWidget);
     });
 
     testWidgets('renders initial state', (WidgetTester tester) async {
@@ -105,7 +105,7 @@ void main() {
       ];
       when(cubit.state).thenReturn(LessonsState.loaded(lessons));
       await pumpTestWidget(tester);
-      final BuildContext context = tester.element(find.byType(LessonsPage));
+      final BuildContext context = tester.element(find.byType(LessonsView));
       expect(find.byType(ListView), findsOneWidget);
       expect(find.text('Test Lektion'), findsOneWidget);
       expect(find.text(context.l10n.lessonsPages(1)), findsOneWidget);
@@ -119,7 +119,7 @@ void main() {
         (WidgetTester tester) async {
       when(cubit.state).thenReturn(const LessonsState.error('Error'));
       await pumpTestWidget(tester);
-      final BuildContext context = tester.element(find.byType(LessonsPage));
+      final BuildContext context = tester.element(find.byType(LessonsView));
 
       expect(find.text('Error'), findsOneWidget);
       expect(find.text(context.l10n.lessonsTryAgain), findsOneWidget);
@@ -149,7 +149,7 @@ void main() {
   testWidgets('shows empty state', (WidgetTester tester) async {
     when(cubit.state).thenReturn(const LessonsState.loaded([]));
     await pumpTestWidget(tester);
-    final BuildContext context = tester.element(find.byType(LessonsPage));
+    final BuildContext context = tester.element(find.byType(LessonsView));
     expect(find.text(context.l10n.lessonsEmpty), findsOneWidget);
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This PR renames `LessonsPage` to `LessonsView` to unify naming. Also, it translates the description for the german localizations to german.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
