### PR TITLE
feat: Add tasks indicator

### DIFF
--- a/lib/features/lesson/view/lesson_view.dart
+++ b/lib/features/lesson/view/lesson_view.dart
@@ -33,6 +33,7 @@ class LessonView extends StatelessWidget {
               ),
             LessonLoaded(:final lesson) => LessonPagesView(
                 pages: lesson.pages,
+                hasTasks: lesson.tasks.isNotEmpty,
               ),
           },
         );

--- a/lib/features/lesson/view/widgets/pages_view.dart
+++ b/lib/features/lesson/view/widgets/pages_view.dart
@@ -7,10 +7,12 @@ import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 class LessonPagesView extends StatefulWidget {
   const LessonPagesView({
     required this.pages,
+    required this.hasTasks,
     super.key,
   });
 
   final List<Page> pages;
+  final bool hasTasks;
 
   static const Key backButtonKey = Key('lessonPagesViewBackButton');
   static const Key forwardButtonKey = Key('lessonPagesViewForwardButton');
@@ -68,12 +70,10 @@ class _LessonPagesViewState extends State<LessonPagesView> {
         children: [
           Column(
             children: [
-              SmoothPageIndicator(
+              _PageAndTasksIndicator(
                 controller: _pageController,
-                count: widget.pages.length,
-                effect: WormEffect(
-                  activeDotColor: Theme.of(context).colorScheme.primary,
-                ),
+                pageCount: widget.pages.length,
+                hasTasks: widget.hasTasks,
               ),
               Expanded(
                 child: PageView.builder(
@@ -145,4 +145,38 @@ class _ForwardButton extends StatelessWidget {
       icon: const Icon(Icons.arrow_forward),
     );
   }
+}
+
+class _PageAndTasksIndicator extends StatelessWidget {
+  const _PageAndTasksIndicator({
+    required this.controller,
+    required this.pageCount,
+    required this.hasTasks,
+  });
+
+  final PageController controller;
+  final int pageCount;
+  final bool hasTasks;
+
+  @override
+  Widget build(BuildContext context) => Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SmoothPageIndicator(
+            controller: controller,
+            count: pageCount,
+            effect: WormEffect(
+              activeDotColor: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          if (hasTasks) ...[
+            const SizedBox(width: 6),
+            const Icon(
+              Icons.task_outlined,
+              size: 20,
+            ),
+          ],
+        ],
+      );
 }

--- a/test/features/lesson/view/lesson_view_test.dart
+++ b/test/features/lesson/view/lesson_view_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lessons_tasks_assignment/domain/content_component.dart';
 import 'package:lessons_tasks_assignment/domain/lesson.dart';
 import 'package:lessons_tasks_assignment/domain/page.dart';
+import 'package:lessons_tasks_assignment/domain/task.dart';
 import 'package:lessons_tasks_assignment/features/lesson/cubit/lesson_cubit.dart';
 import 'package:lessons_tasks_assignment/features/lesson/cubit/lesson_state.dart';
 import 'package:lessons_tasks_assignment/features/lesson/view/lesson_view.dart';
@@ -78,6 +79,43 @@ void main() {
       final pagesView =
           tester.widget<LessonPagesView>(find.byType(LessonPagesView));
       expect(pagesView.pages, lesson.pages);
+    });
+
+    testWidgets('passes false to LessonPagesView when no tasks',
+        (WidgetTester tester) async {
+      const lesson = Lesson(
+        id: '1',
+        title: {'en': 'Test Lesson', 'de': 'Test Lektion'},
+        pages: [],
+        tasks: [],
+      );
+      when(cubit.state).thenReturn(const LessonLoaded(lesson));
+      await pumpTestWidget(tester);
+      final pagesView =
+          tester.widget<LessonPagesView>(find.byType(LessonPagesView));
+      expect(pagesView.hasTasks, false);
+    });
+
+    testWidgets('passes true to LessonPagesView when tasks',
+        (WidgetTester tester) async {
+      const lesson = Lesson(
+        id: '1',
+        title: {'en': 'Test Lesson', 'de': 'Test Lektion'},
+        pages: [],
+        tasks: [
+          Task(
+            id: '1',
+            question: {'en': 'Test Question', 'de': 'Test Frage'},
+            options: [],
+            correctAnswerIds: [],
+          ),
+        ],
+      );
+      when(cubit.state).thenReturn(const LessonLoaded(lesson));
+      await pumpTestWidget(tester);
+      final pagesView =
+          tester.widget<LessonPagesView>(find.byType(LessonPagesView));
+      expect(pagesView.hasTasks, true);
     });
   });
 }

--- a/test/features/lesson/view/widgets/pages_view_test.dart
+++ b/test/features/lesson/view/widgets/pages_view_test.dart
@@ -1,5 +1,4 @@
-import 'dart:ui';
-
+import 'package:flutter/material.dart' hide Page;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lessons_tasks_assignment/domain/content_component.dart';
 import 'package:lessons_tasks_assignment/domain/page.dart';
@@ -14,11 +13,15 @@ void main() {
     Future<void> pumpTestWidget(
       WidgetTester tester, {
       required List<Page> pages,
+      bool hasTasks = false,
       Locale? locale,
     }) {
       return tester.pumpApp(
         locale: locale,
-        widget: LessonPagesView(pages: pages),
+        widget: LessonPagesView(
+          pages: pages,
+          hasTasks: hasTasks,
+        ),
       );
     }
 
@@ -89,6 +92,24 @@ void main() {
         find.byType(SmoothIndicator),
       );
       expect(updatedSmoothIndicator.offset, 1);
+    });
+
+    testWidgets('renders task icon when hasTasks is true',
+        (WidgetTester tester) async {
+      await pumpTestWidget(tester, pages: [], hasTasks: true);
+      expect(find.byIcon(Icons.task_outlined), findsOneWidget);
+    });
+
+    testWidgets('hides task icon by default', (WidgetTester tester) async {
+      await pumpTestWidget(tester, pages: []);
+      expect(find.byIcon(Icons.task_outlined), findsNothing);
+    });
+
+    testWidgets('hides task icon when hasTasks is false',
+        (WidgetTester tester) async {
+      // ignore: avoid_redundant_argument_values
+      await pumpTestWidget(tester, pages: [], hasTasks: false);
+      expect(find.byIcon(Icons.task_outlined), findsNothing);
     });
 
     testWidgets('back button is disabled on first page',


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This PR adds an indicator to the `LessonPageView` that indicates if a lesson has tasks.

![Screenshot 2024-12-08 at 07 38 19](https://github.com/user-attachments/assets/108d3393-e14e-4577-b845-8bd1e57c236e)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
