### PR TITLE
fix: Navigate to tasks when no pages

### DIFF
--- a/lib/features/lesson/view/widgets/pages_view.dart
+++ b/lib/features/lesson/view/widgets/pages_view.dart
@@ -62,7 +62,8 @@ class _LessonPagesViewState extends State<LessonPagesView> {
   }
 
   void _navigateForward() {
-    if (_pageController.page == widget.pages.length - 1) {
+    final hasNoPages = widget.pages.isEmpty;
+    if (hasNoPages || _pageController.page == widget.pages.length - 1) {
       TasksRoute(id: widget.id).go(context);
     } else {
       _pageController.nextPage(

--- a/test/features/lesson/view/widgets/pages_view_test.dart
+++ b/test/features/lesson/view/widgets/pages_view_test.dart
@@ -252,6 +252,20 @@ void main() {
 
         verify(router.go(const TasksRoute(id: 'id').location)).called(1);
       });
+
+      testWidgets(
+          'forward button is pressed with no pages when hasTasks is true',
+          (WidgetTester tester) async {
+        await pumpWithGoRouter(
+          tester,
+          pages: [],
+        );
+
+        await tester.tap(find.byKey(LessonPagesView.forwardButtonKey));
+        await tester.pumpAndSettle();
+
+        verify(router.go(const TasksRoute(id: 'id').location)).called(1);
+      });
     });
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This PR fixes a bug that prevented navigating to tasks when a lesson had no pages

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
